### PR TITLE
Fix connector input texture that looks like a call input

### DIFF
--- a/ProtoFluxOverhaul/ProtoFluxOverhaul.cs
+++ b/ProtoFluxOverhaul/ProtoFluxOverhaul.cs
@@ -62,7 +62,7 @@ public class ProtoFluxOverhaul : ResoniteMod {
 	public static readonly ModConfigurationKey<Uri> ROUNDED_TEXTURE = new("roundedTexture", "Rounded Texture URL", () => new Uri("resdb:///3ee5c0335455c19970d877e2b80f7869539df43fccb8fc64b38e320fc44c154f.png"));
 
 	[AutoRegisterConfigKey]
-	public static readonly ModConfigurationKey<Uri> CONNECTOR_INPUT_TEXTURE = new("connectorInputTexture", "Connector Input Texture URL", () => new Uri("resdb:///59586a2c3a1f0bab46fd6b24103fba2f00f9dd98d438d98226b5b54859b30b30.png"));
+	public static readonly ModConfigurationKey<Uri> CONNECTOR_INPUT_TEXTURE = new("connectorInputTexture", "Connector Input Texture URL", () => new Uri("resdb:///baff0353323659064d2692e3609025d2348998798ee6031cb777fbd4a13f4360.png"));
 
 	[AutoRegisterConfigKey]
 	public static readonly ModConfigurationKey<Uri> CONNECTOR_OUTPUT_TEXTURE = new("connectorOutputTexture", "Connector Output Texture URL", () => new Uri("resdb:///baff0353323659064d2692e3609025d2348998798ee6031cb777fbd4a13f4360.png")); 


### PR DESCRIPTION
I replaced the normal input texture with the same the output uses.
Before:
![brave_11_09_2025_10-55-04-862](https://github.com/user-attachments/assets/a5c1cdf7-b02c-47f4-9a5c-db5d9023a1af)
After:
![Renderite Renderer_11_09_2025_10-55-00-123](https://github.com/user-attachments/assets/f6efc996-82fc-4315-aa61-7d57c0720a2f)

Fixes #22 

I'm not sure if it changes existing configs.